### PR TITLE
Add automatically updating copyright year to footer

### DIFF
--- a/app/index.jade
+++ b/app/index.jade
@@ -112,8 +112,10 @@ html
           .row
             .col-sm-6
               p
-                | Copyright © 2014&nbsp;&nbsp;
-                a(href='http://www.aerobatic.com') Aerobatic LLC
+                | Copyright ©&nbsp;
+                script(type='text/javascript').
+                  document.write(new Date().getFullYear());
+                a(href='http://www.aerobatic.com') &nbsp;Aerobatic LLC
                 | &nbsp;All rights reserved.
             .col-sm-6
               ul.socialNetwork.pull-right


### PR DESCRIPTION
The Aerobatic.com footer currently lists the year as 2014. This pull request uses some basic JavaScript to automatically display the current year. Annual updates are no longer necessary.
